### PR TITLE
feat: PCでも価格変動トレンドアイコンを表示 + E2Eテスト追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ package-lock.json
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/playwright-results.xml
+/.playwright-mcp
+
 
 # next.js
 /.next/

--- a/components/PriceValueCell.tsx
+++ b/components/PriceValueCell.tsx
@@ -62,8 +62,9 @@ export function PriceValueCell({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className={`text-center ${isHighlighted ? "text-green-600 font-semibold" : ""}`}>
-          {displayValue}
+        <div className={`flex items-center justify-center gap-1 ${isHighlighted ? "text-green-600 font-semibold" : ""}`}>
+          {value > 0 && <TrendIcon className={`h-4 w-4 ${colorClass}`} />}
+          <span>{displayValue}</span>
         </div>
       </TooltipTrigger>
       <TooltipContent sideOffset={6}>{tooltipContent}</TooltipContent>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:debug": "playwright test --debug",
+    "e2e:report": "playwright show-report",
+    "e2e:setup": "node scripts/setup-e2e.mjs"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
@@ -39,6 +44,7 @@
     "web-push": "^3.6.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.1.5",
@@ -46,10 +52,10 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.1",
     "@types/node": "^20",
-    "@vitest/coverage-v8": "^4.0.18",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/web-push": "^3.6.4",
+    "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.22",
     "baseline-browser-mapping": "^2.9.4",
     "eslint": "^9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,103 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E test configuration for Resonance Trade Center.
+ *
+ * Test matrix:
+ *   - chromium-desktop  : 1280×720  – exercises Tooltip + desktop PriceValueCell branch
+ *   - chromium-mobile   : 390×844   – exercises direct-icon mobile PriceValueCell branch
+ *
+ * The dev server is started automatically via webServer.  If a server is
+ * already running on port 3000 (local dev workflow), it is reused.
+ *
+ * Artifacts (screenshot, video, trace) are captured on failure / first retry
+ * so debugging CI failures is straightforward.
+ */
+export default defineConfig({
+  // ─── Test discovery ──────────────────────────────────────────────────────
+  testDir: './tests/e2e',
+
+  // ─── Timeouts ────────────────────────────────────────────────────────────
+  /** Per-test timeout (ms). */
+  timeout: 30_000,
+  /** expect() assertion timeout (ms). */
+  expect: { timeout: 10_000 },
+
+  // ─── Parallelism / reliability ────────────────────────────────────────────
+  fullyParallel: true,
+  /** Fail the suite immediately if a test uses test.only() in CI. */
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  // ─── Reporters ───────────────────────────────────────────────────────────
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+    ...(process.env.CI
+      ? ([['junit', { outputFile: 'playwright-results.xml' }]] as const)
+      : []),
+  ],
+
+  // ─── Shared browser context options ──────────────────────────────────────
+  use: {
+    baseURL: 'http://localhost:3000',
+
+    /** Capture a trace zip on the first retry of a failing test. */
+    trace: 'on-first-retry',
+    /** Capture a screenshot whenever a test fails. */
+    screenshot: 'only-on-failure',
+    /** Record a video on the first retry of a failing test. */
+    video: 'on-first-retry',
+
+    /**
+     * The app redirects HTTP→HTTPS when `x-forwarded-proto: http` is present.
+     * In local dev this header is never set, so plain HTTP works fine.
+     */
+    ignoreHTTPSErrors: true,
+
+    /**
+     * Japanese locale so any Intl-based formatting (e.g. price.toLocaleString)
+     * produces predictable output regardless of the CI runner's locale.
+     */
+    locale: 'ja-JP',
+  },
+
+  // ─── Browser projects ────────────────────────────────────────────────────
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        /**
+         * ≥ 768 px  →  useIsMobile() returns false
+         *            →  PriceValueCell renders icons inside <Tooltip>
+         */
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+    {
+      name: 'chromium-mobile',
+      use: {
+        ...devices['Pixel 5'],
+        /**
+         * < 768 px  →  useIsMobile() returns true
+         *            →  PriceValueCell renders icons directly (no Tooltip)
+         */
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+
+  // ─── Dev server ──────────────────────────────────────────────────────────
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    /** Reuse an already-running server during local development. */
+    reuseExistingServer: !process.env.CI,
+    /** Give Next.js up to 2 minutes to compile and start. */
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 8.21.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.0.7(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 1.6.1(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -64,7 +64,7 @@ importers:
         version: 0.556.0(react@19.2.0)
       next:
         specifier: 16.0.7
-        version: 16.0.7(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.7(@babel/core@7.28.5)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -84,6 +84,9 @@ importers:
         specifier: ^3.6.7
         version: 3.6.7
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
@@ -880,6 +883,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -2464,6 +2472,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3130,6 +3143,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4420,6 +4443,10 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@popperjs/core@2.11.8': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -5267,9 +5294,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.0.7(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@vercel/analytics@1.6.1(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
-      next: 16.0.7(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.7(@babel/core@7.28.5)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.25)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2))':
@@ -6137,6 +6164,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6663,7 +6693,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.0.7(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.59.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.0.7
       '@swc/helpers': 0.5.15
@@ -6681,6 +6711,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.0.7
       '@next/swc-win32-arm64-msvc': 16.0.7
       '@next/swc-win32-x64-msvc': 16.0.7
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6794,6 +6825,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/e2e/fixtures/tradeData.ts
+++ b/tests/e2e/fixtures/tradeData.ts
@@ -1,0 +1,21 @@
+export const mockTradeResponse = {
+  fetchTime: new Date().toISOString(),
+  stations: [
+    {
+      stationId: "1001",
+      buyItems: [
+        { itemId: "1", price: 1000, quota: 1.2, is_rise: true, trend: 1, stock: 100 },
+        { itemId: "2", price: 800, quota: 0.9, is_rise: false, trend: 0, stock: 50 },
+      ],
+      sellItems: [],
+    },
+    {
+      stationId: "1002",
+      buyItems: [
+        { itemId: "1", price: 950, quota: 1.1, is_rise: true, trend: 1, stock: 80 },
+        { itemId: "2", price: 820, quota: 0.85, is_rise: false, trend: 0, stock: 60 },
+      ],
+      sellItems: [],
+    },
+  ],
+};

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from './pages/HomePage';
+import { mockTradeResponse } from './fixtures/tradeData';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('/api/trade', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockTradeResponse),
+    })
+  );
+});
+
+test('ホームページが表示される', async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+  await expect(page).toHaveTitle(/レゾナンス/);
+});
+
+test('タブ切り替えが機能する', async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+
+  // デフォルトは「商品一覧」タブ
+  await expect(page.getByRole('tab', { name: '商品一覧' })).toHaveAttribute('data-state', 'active');
+
+  // 「価格表」タブに切り替え
+  await home.switchToFavoritesTab();
+  await expect(page.getByRole('tab', { name: '価格表' })).toHaveAttribute('data-state', 'active');
+});
+
+test('「商品一覧」タブにカードが表示される', async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+
+  // タブパネルが存在することを確認
+  const tabPanel = page.getByRole('tabpanel', { name: '商品一覧' });
+  await expect(tabPanel).toBeVisible();
+});
+
+test('ナビゲーションバーが表示される', async ({ page }) => {
+  const home = new HomePage(page);
+  await home.goto();
+  // ナビゲーションリンク（価格表ページへのリンク）が存在する
+  await expect(page.getByRole('link', { name: /価格表/i }).first()).toBeVisible();
+});

--- a/tests/e2e/pages/HomePage.ts
+++ b/tests/e2e/pages/HomePage.ts
@@ -1,0 +1,22 @@
+import { Page } from '@playwright/test';
+
+export class HomePage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('/');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async switchToFavoritesTab() {
+    await this.page.getByRole('tab', { name: '価格表' }).click();
+  }
+
+  async switchToCardsTab() {
+    await this.page.getByRole('tab', { name: '商品一覧' }).click();
+  }
+
+  getCardsTabContent() {
+    return this.page.locator('[data-state="active"]').filter({ hasText: '' });
+  }
+}

--- a/tests/e2e/pages/PricesPage.ts
+++ b/tests/e2e/pages/PricesPage.ts
@@ -1,0 +1,28 @@
+import { Page } from '@playwright/test';
+
+export class PricesPage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('/prices');
+    await this.page.waitForSelector('table', { timeout: 15000 });
+  }
+
+  async waitForTableRows() {
+    await this.page.waitForSelector('tbody tr', { timeout: 15000 });
+  }
+
+  getPriceCells() {
+    // All data cells in the price table (excluding first column = item name)
+    return this.page.locator('tbody tr td:not(:first-child)');
+  }
+
+  getTrendIcons() {
+    // ArrowUp / ArrowDown from lucide-react are rendered as <svg>
+    return this.page.locator('tbody tr td svg');
+  }
+
+  getPercentToggle() {
+    return this.page.getByRole('switch');
+  }
+}

--- a/tests/e2e/prices.spec.ts
+++ b/tests/e2e/prices.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import { PricesPage } from './pages/PricesPage';
+import { mockTradeResponse } from './fixtures/tradeData';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('/api/trade', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockTradeResponse),
+    })
+  );
+});
+
+test('価格表ページが表示される', async ({ page }) => {
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await expect(page.locator('table')).toBeVisible();
+});
+
+test('価格セルにトレンドアイコン（↑/↓）が表示される', async ({ page }) => {
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  // テーブル内のアイコン（SVG）が存在することを確認
+  const trendIcons = prices.getTrendIcons();
+  await expect(trendIcons.first()).toBeVisible({ timeout: 10000 });
+  expect(await trendIcons.count()).toBeGreaterThan(0);
+});
+
+test('デスクトップ: トレンドアイコンが価格セル内に存在する', async ({ page, viewport }) => {
+  test.skip(!viewport || viewport.width < 768, 'デスクトップのみ');
+
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  // 最初の価格セル（2列目）にアイコンが含まれる
+  const firstPriceCell = page.locator('tbody tr:first-child td:nth-child(2)');
+  await expect(firstPriceCell.locator('svg')).toBeVisible();
+});
+
+test('モバイル: トレンドアイコンが価格セル内に存在する', async ({ page, viewport }) => {
+  test.skip(!viewport || viewport.width >= 768, 'モバイルのみ');
+
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  const firstPriceCell = page.locator('tbody tr:first-child td:nth-child(2)');
+  await expect(firstPriceCell.locator('svg')).toBeVisible();
+});
+
+test('デスクトップ: 価格セルにホバーするとツールチップが表示される', async ({ page, viewport }) => {
+  test.skip(!viewport || viewport.width < 768, 'デスクトップのみ');
+
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  const firstPriceCell = page.locator('tbody tr:first-child td:nth-child(2)');
+  await firstPriceCell.hover();
+
+  // ツールチップが表示される（role="tooltip" または data-radix-popper-content-wrapper）
+  await expect(page.locator('[role="tooltip"]')).toBeVisible({ timeout: 5000 });
+});
+
+test('%表示トグルで表示が切り替わる', async ({ page }) => {
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  // % トグルを有効化
+  const toggle = prices.getPercentToggle();
+  await toggle.click();
+
+  // セルの表示が % 形式に変わる（例: "120%"）
+  const cells = page.locator('tbody tr td:not(:first-child)');
+  const firstCellText = await cells.first().innerText();
+  expect(firstCellText).toMatch(/%|－/);
+});
+
+test('お気に入り商品の星アイコンをクリックするとlocalStorageに保存される', async ({ page }) => {
+  const prices = new PricesPage(page);
+  await prices.goto();
+  await prices.waitForTableRows();
+
+  // 最初の商品の星アイコンをクリック
+  const starButton = page.locator('tbody tr:first-child [aria-label="toggle favorite"]');
+  await starButton.click();
+
+  // localStorage に保存されていることを確認
+  const saved = await page.evaluate(() => localStorage.getItem('favorites-prices'));
+  expect(saved).not.toBeNull();
+  const favorites = JSON.parse(saved!);
+  expect(favorites.length).toBeGreaterThan(0);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## 変更内容

### 修正
- **価格変動トレンドアイコンをPCでも表示**
  - PriceValueCell のPCレイアウト（Tooltip内）にも ArrowUp / ArrowDown アイコンを追加
  - モバイルと同様に、価格セルの左側に up/down アローが表示されるようになった
  - ホバーでツールチップを表示する動作はそのまま維持

### E2Eテスト環境を構築（Playwright）
- playwright.config.ts: Desktop Chrome(1280px) + Mobile Chrome(390px)
- tests/e2e/fixtures/tradeData.ts: /api/trade モックデータ
- tests/e2e/pages/: Page Object Model (HomePage, PricesPage)
- tests/e2e/home.spec.ts: ホームページ 4テスト
- tests/e2e/prices.spec.ts: 価格表 7テスト

## テスト結果
Desktop Chrome: 10 passed / 1 skipped
Mobile Chrome:   9 passed / 2 skipped

## 実行方法
pnpm e2e         # 全E2Eテスト実行
pnpm e2e:report  # HTMLレポート表示