### PR TITLE
feat: 商品単位まとめの価格ソートオプションを追加 (#48)

### DIFF
--- a/components/sortSelector.tsx
+++ b/components/sortSelector.tsx
@@ -8,6 +8,12 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useDebouncedCallback } from "@/hooks/useDebouncedCallback";
 
+const SORT_LABELS: Record<string, string> = {
+  'price-high': '価格：高い順',
+  'price-high-grouped': '価格：高い順（商品まとめ）',
+  'price-low': '価格：低い順',
+};
+
 export default function SortSelector({
   sortOrder,
   onSortChange,
@@ -20,7 +26,7 @@ export default function SortSelector({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="outline">
-          {sortOrder === 'price-high' ? '価格：高い順' : sortOrder === 'price-low' ? '価格：低い順' : '並び順'}
+          {SORT_LABELS[sortOrder] ?? '並び順'}
           <ChevronDown className="ml-2 h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
@@ -30,6 +36,9 @@ export default function SortSelector({
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => debouncedSortChange('price-high')}>
           価格：高い順
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => debouncedSortChange('price-high-grouped')}>
+          価格：高い順（商品まとめ）
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => debouncedSortChange('price-low')}>
           価格：低い順

--- a/hooks/useFilteredAndSortedItems.ts
+++ b/hooks/useFilteredAndSortedItems.ts
@@ -7,9 +7,25 @@ export function useFilteredAndSortedItems(
     return item.goodsJp.toLowerCase().includes(searchQuery.toLowerCase());
   });
 
-  // Keep original order for the 'default' sort (no reordering)
   if (sortOrder === 'default') {
     return filteredItems;
+  }
+
+  if (sortOrder === 'price-high-grouped') {
+    // ① goodsJp でグルーピング
+    const groups: Record<string, typeof allItems> = {};
+    for (const item of filteredItems) {
+      if (!groups[item.goodsJp]) groups[item.goodsJp] = [];
+      groups[item.goodsJp].push(item);
+    }
+    // ② 各グループ内を price 降順でソート
+    for (const key of Object.keys(groups)) {
+      groups[key].sort((a, b) => b.price - a.price);
+    }
+    // ③④ グループを最大価格（代表値）で降順ソートし、フラット化
+    return Object.values(groups)
+      .sort((a, b) => b[0].price - a[0].price)
+      .flat();
   }
 
   const sortedItems = filteredItems.toSorted((a: any, b: any) => {

--- a/tests/unit/hooks/useFilteredAndSortedItems.test.ts
+++ b/tests/unit/hooks/useFilteredAndSortedItems.test.ts
@@ -33,4 +33,56 @@ describe('useFilteredAndSortedItems', () => {
     const result = useFilteredAndSortedItems(items, 'ビ', 'default');
     expect(result.map((item) => item.goodsJp)).toEqual(['ビール']);
   });
+
+  describe('price-high-grouped', () => {
+    it('keeps same-product items together, sorted by max price descending', () => {
+      const multiStationItems = [
+        { goodsJp: 'シルクのダウン枕', price: 850, stationId: 'タワー' },
+        { goodsJp: 'レースドレス',     price: 900, stationId: 'タワー' },
+        { goodsJp: 'シルクのダウン枕', price: 1000, stationId: 'ケープ' },
+      ];
+      const result = useFilteredAndSortedItems(multiStationItems, '', 'price-high-grouped');
+      // シルクのダウン枕 group max=1000 > レースドレス group max=900
+      // シルクのダウン枕 group is internally sorted: ケープ(1000) then タワー(850)
+      expect(result.map((i) => `${i.goodsJp}(${i.stationId})`)).toEqual([
+        'シルクのダウン枕(ケープ)',
+        'シルクのダウン枕(タワー)',
+        'レースドレス(タワー)',
+      ]);
+    });
+
+    it('sorts groups by their max price, not individual item price', () => {
+      const multiStationItems = [
+        { goodsJp: '嵐心錦衣', price: 1200, stationId: 'タワー' },
+        { goodsJp: '嵐心錦衣', price: 900,  stationId: 'ケープ' },
+        { goodsJp: 'シルクのダウン枕', price: 1100, stationId: 'ケープ' },
+        { goodsJp: 'シルクのダウン枕', price: 700,  stationId: 'タワー' },
+      ];
+      const result = useFilteredAndSortedItems(multiStationItems, '', 'price-high-grouped');
+      // 嵐心錦衣 max=1200 > シルクのダウン枕 max=1100
+      expect(result.map((i) => i.goodsJp)).toEqual([
+        '嵐心錦衣', '嵐心錦衣',
+        'シルクのダウン枕', 'シルクのダウン枕',
+      ]);
+      // within 嵐心錦衣: タワー(1200) before ケープ(900)
+      expect(result[0].stationId).toBe('タワー');
+      expect(result[1].stationId).toBe('ケープ');
+    });
+
+    it('returns single-item groups in price descending order', () => {
+      const result = useFilteredAndSortedItems(items, '', 'price-high-grouped');
+      expect(result.map((item) => item.goodsJp)).toEqual(['ワイン', 'ビール', 'アップル']);
+    });
+
+    it('filters by search query before grouping', () => {
+      const multiStationItems = [
+        { goodsJp: 'シルクのダウン枕', price: 1000, stationId: 'ケープ' },
+        { goodsJp: 'レースドレス',     price: 900,  stationId: 'タワー' },
+        { goodsJp: 'シルクのダウン枕', price: 850,  stationId: 'タワー' },
+      ];
+      const result = useFilteredAndSortedItems(multiStationItems, 'シルク', 'price-high-grouped');
+      expect(result).toHaveLength(2);
+      expect(result.every((i) => i.goodsJp === 'シルクのダウン枕')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Issue #48 で提案された「商品単位での価格ソート方式」を実装します。

## 問題

「価格：高い順」でソートすると、同一商品が複数ステーションに登録されている場合に他商品が間に挟まる問題がありました。

例: シルクのダウン枕(ケープ, 1000) → レースドレス(タワー, 900) → シルクのダウン枕(タワー, 850)

## 解決策

新しいソートオプション「**価格：高い順（商品まとめ）**」(\price-high-grouped\) を追加しました。

### アルゴリズム
1. \goodsJp\ でアイテムをグループ化
2. 各グループ内を \price\ 降順でソート
3. グループの代表値 = グループ内の最高価格
4. グループを代表値の降順でソートして連結

**期待される表示順:**
嵐心錦衣(タワー) → 嵐心錦衣(ケープ) → シルクのダウン枕(ケープ) → シルクのダウン枕(タワー) → …

## 変更ファイル

| ファイル | 変更内容 |
|--------|--------|
| \hooks/useFilteredAndSortedItems.ts\ | \price-high-grouped\ ソートロジックを追加 |
| \components/sortSelector.tsx\ | UIに「価格：高い順（商品まとめ）」オプションを追加、ラベル表示をRecord化 |
| \	ests/unit/hooks/useFilteredAndSortedItems.test.ts\ | 新ソートの4テストケースを追加 |

既存の \price-high\ / \price-low\ / \default\ ソートは変更していません。

Closes #48