### PR TITLE
feat: Vercel Cron Job による価格データ更新頻度の改善（Issue #24）

### DIFF
--- a/.github/workflows/update-trade.yml
+++ b/.github/workflows/update-trade.yml
@@ -1,8 +1,6 @@
-name: Update trade data
+name: Update trade data (manual)
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -16,4 +14,4 @@ jobs:
       
       - name: Request API to update trade data
         run: |
-          curl -X POST https://resonance-rate-checker.vercel.app/api/trade
+          curl -X POST https://resonance.drakontia.com/api/trade

--- a/app/api/cron/revalidate/route.ts
+++ b/app/api/cron/revalidate/route.ts
@@ -1,0 +1,20 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret) {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  revalidateTag('trade');
+
+  return NextResponse.json({
+    revalidated: true,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/cron/revalidate/route.ts
+++ b/app/api/cron/revalidate/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  revalidateTag('trade');
+  revalidateTag('trade', {});
 
   return NextResponse.json({
     revalidated: true,

--- a/app/api/trade/route.ts
+++ b/app/api/trade/route.ts
@@ -80,6 +80,6 @@ export async function GET() {
 }
 
 export async function POST() {
-  revalidateTag('trade');
+  revalidateTag('trade', {});
   return NextResponse.json({ revalidated: true });
 }

--- a/app/api/trade/route.ts
+++ b/app/api/trade/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   
   const res = await fetch(url, {
     next: {
-      revalidate: 600, // 10分キャッシュ
+      revalidate: 300, // 5分キャッシュ
       tags: ['trade'],
     },
   });
@@ -80,6 +80,6 @@ export async function GET() {
 }
 
 export async function POST() {
-  revalidateTag('trade', 'max');
+  revalidateTag('trade');
   return NextResponse.json({ revalidated: true });
 }

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -20,7 +20,7 @@ export function Title() {
                 variant="h6" 
                 sx={{ opacity: 0.9, fontSize: { xs: '0.9rem', sm: '1.25rem' } }}
             >
-                リアルタイム商品価格表示
+                リアルタイム商品価格表示（最大5分更新）
             </Typography>
             </CardContent>
         </Card>

--- a/tests/unit/api/cron-revalidate-route.test.ts
+++ b/tests/unit/api/cron-revalidate-route.test.ts
@@ -1,0 +1,89 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import { GET } from '../../../app/api/cron/revalidate/route';
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  cacheTag: vi.fn(),
+}));
+
+// NextResponse.jsonをモック
+vi.spyOn(NextResponse, 'json').mockImplementation((data) => {
+  return { json: () => Promise.resolve(data), data } as any;
+});
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return {
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+  } as unknown as NextRequest;
+}
+
+describe('Cron Revalidate API Route', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.CRON_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('CRON_SECRETが設定されていない場合', () => {
+    it('認証なしでリクエストが成功し、revalidateTagが呼ばれること', async () => {
+      const request = makeRequest();
+      const response = await GET(request);
+      const result = await response.json();
+
+      expect(revalidateTag).toHaveBeenCalledWith('trade', {});
+      expect(result.revalidated).toBe(true);
+      expect(result.timestamp).toBeDefined();
+    });
+  });
+
+  describe('CRON_SECRETが設定されている場合', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('正しいAuthorizationヘッダーでリクエストが成功すること', async () => {
+      const request = makeRequest({ authorization: 'Bearer test-secret' });
+      const response = await GET(request);
+      const result = await response.json();
+
+      expect(revalidateTag).toHaveBeenCalledWith('trade', {});
+      expect(result.revalidated).toBe(true);
+      expect(result.timestamp).toBeDefined();
+    });
+
+    it('間違ったAuthorizationヘッダーで401が返ること', async () => {
+      vi.spyOn(NextResponse, 'json').mockImplementationOnce((data, init) => {
+        return { json: () => Promise.resolve(data), data, status: init?.status } as any;
+      });
+
+      const request = makeRequest({ authorization: 'Bearer wrong-secret' });
+      const response = await GET(request);
+
+      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+    });
+
+    it('Authorizationヘッダーなしで401が返ること', async () => {
+      vi.spyOn(NextResponse, 'json').mockImplementationOnce((data, init) => {
+        return { json: () => Promise.resolve(data), data, status: init?.status } as any;
+      });
+
+      const request = makeRequest();
+      const response = await GET(request);
+
+      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/tests/unit/components/updateTrade-route.test.ts
+++ b/tests/unit/components/updateTrade-route.test.ts
@@ -31,7 +31,7 @@ describe('UpdateTrade API Route', () => {
     const response = await POST();
     const result = await response.json();
 
-    expect(revalidateTag).toHaveBeenCalledWith('trade');
+    expect(revalidateTag).toHaveBeenCalledWith('trade', {});
     expect(result.revalidated).toBe(true);
   });
 

--- a/tests/unit/components/updateTrade-route.test.ts
+++ b/tests/unit/components/updateTrade-route.test.ts
@@ -31,7 +31,7 @@ describe('UpdateTrade API Route', () => {
     const response = await POST();
     const result = await response.json();
 
-    expect(revalidateTag).toHaveBeenCalledWith('trade', 'max');
+    expect(revalidateTag).toHaveBeenCalledWith('trade');
     expect(result.revalidated).toBe(true);
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "crons": [
+    {
+      "path": "/api/cron/revalidate",
+      "schedule": "*/5 * * * *"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 概要

Issue #24 で報告された価格表示の遅延問題に対処します。

Vercel Pro プランへの移行により Vercel Cron Job が使用可能になったため、GitHub Actions による10分毎の更新から **Vercel Cron による5分毎の更新** に切り替えます。

## 変更内容

### 新規ファイル
- `app/api/cron/revalidate/route.ts` — Vercel Cron 専用の GET エンドポイント
  - `CRON_SECRET` 環境変数による認証（未設定時はスキップ）
  - `revalidateTag('trade')` でキャッシュを無効化

### 更新ファイル
- `vercel.json` — Vercel Cron Job を追加（`*/5 * * * *` で `/api/cron/revalidate` を呼び出し）
- `app/api/trade/route.ts`
  - キャッシュ TTL を `600s → 300s`（10分 → 5分）に短縮
  - `revalidateTag('trade', 'max')` の誤った第2引数を削除（バグ修正）
- `.github/workflows/update-trade.yml`
  - 定期スケジュール（`*/10 * * * *`）を削除し `workflow_dispatch` のみ残す
  - URL を旧 Vercel URL → `https://resonance.drakontia.com` に修正
- `components/title.tsx` — 「リアルタイム商品価格表示」→「リアルタイム商品価格表示（最大5分更新）」に変更

## データ更新フロー（変更後）

```
外部 TRADE_API_URL（ゲーム運営側）
  └─> Vercel Cron（5分毎）→ GET /api/cron/revalidate → revalidateTag('trade')
        └─> 次回 GET /api/trade で外部 API から最新データ取得（TTL 5分）
              └─> クライアント（5分毎の自動リフレッシュ）→ ユーザー表示
```

**最大遅延：約5分**（以前は最大約20分）

## 必要な Vercel 設定

`CRON_SECRET` 環境変数を Vercel コンソールで設定してください（任意ですが推奨）。

Vercel が Cron リクエストに `Authorization: Bearer {CRON_SECRET}` ヘッダーを付加し、不正アクセスを防ぎます。

Closes #24